### PR TITLE
[query][s]: make sure we have exact match for keywords - refs #19

### DIFF
--- a/metastore/models.py
+++ b/metastore/models.py
@@ -97,7 +97,7 @@ def build_dsl(kind_params, userid, kw):
     for k, v_arr in kw.items():
         dsl['bool']['must'].append({
                 'bool': {
-                    'should': [{'match': {k: json.loads(v)}}
+                    'should': [{'term': {k: json.loads(v)}}
                                for v in v_arr],
                     'minimum_should_match': 1
                 }


### PR DESCRIPTION
We need exact matches when filtering events by dataset names, or we are getting multiple matches when dataset name is more than one word. eg http://api.datahub.io/metastore/search/events?owner=%22core%22&dataset=%22co2-ppm%22

PR uses "term" query match when filtering by query parameters other than `"q"` Eg `?dataset=my-dataset` or `?owner=owner-id`. "term" matching finds documents with **exact** match.

Though we still need to reindex the ES with the appropriate analyzer. We will not get the match with "term" query and "standard analyzer". We should change it to `keywords`. See more info here https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-term-query.html#CO201-2